### PR TITLE
Add a check for out of bounds slot sets for the `dev[slot]` syntax.

### DIFF
--- a/hyper_systems/devices/device.py
+++ b/hyper_systems/devices/device.py
@@ -73,7 +73,13 @@ def get_valid_type_for_attr(attr):
 def set_slot_value(self, slot, value):
     if not isinstance(slot, int):
         raise TypeError("the attribute slot must be an int value")
-    self._rvalues[str(slot)] = value
+    slot_key = str(slot)
+    if slot_key not in self._rvalues:
+        raise TypeError(
+            "cannot set value: no read attribute for slot %s found in device with schema %d"
+            % (slot_key, self.device_class_id)
+        )
+    self._rvalues[slot_key] = value
 
 
 def get_slot_value(self, slot):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -110,5 +110,15 @@ assert dev1.uptime_ms_5 is None and dev1.veml7700_ambient_light_2 is None
 dev1[5] = 1000
 assert dev1[5] == 1000
 
+# set value by slot out of bounds
+try:
+  dev1[999] = 42
+  assert False
+except TypeError as err:
+  assert (
+    err.args[0]
+    == "cannot set value: no read attribute for slot 999 found in device with schema 12"
+  )
+
 print(dev1)
-print(dev1.attributes)
+print(dev1.message)


### PR DESCRIPTION
Fixes #1 