### PR TITLE
Vendor device id fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ from hyper_systems.http import Client
 
 # Load the device schema.
 SCHEMA_FILE = "<path to downloaded schema file>"
-schema = hyper.Schema.load(SCHEMA_FILE)
+schema = Schema.load(SCHEMA_FILE)
 
 # Initialize the device with a schema and a unique id.
-device_id = "00:00:00:00:01"
-device = hyper.Device.from_schema(schema, device_id)
+device_id = "00:00:00:00:00:01"
+device = Device.from_schema(schema, device_id)
 ```
 
 The device schema contains the full description of the properties of the device. Note that multiple devices can match the same device schema as long as they have different device ids.
@@ -105,7 +105,7 @@ You can set any attribute values available on the device. Setting all attributes
 Once your device is initialized and has the attribute values set, you can publish them to the hyper.systems platform.
 
 ```python
-hyper_client = hyper.http.Client(
+hyper_client = Client(
     api_url=HYPER_API_URL,
     api_key=HYPER_API_KEY,
     site_id=HYPER_SITE_ID

--- a/hyper_systems/devices/device.py
+++ b/hyper_systems/devices/device.py
@@ -220,8 +220,8 @@ def dispatch(self, message):
             f(value)
 
 
-def validate_vendor_device_id(id_format, id):
-    if id_format == "Macaddr":
+def validate_vendor_device_id(vendor_device_id_format, id):
+    if vendor_device_id_format.kind == "Macaddr":
         if len(id) != 17:
             raise ValueError("the vendor device id must a valid MAC address")
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -9,6 +9,16 @@ SCHEMA_FILE = os.path.join(PROJECT_ROOT, "./tests/hyper_device_schema_12.json")
 schema = Schema.load(SCHEMA_FILE)
 dev1 = Device.from_schema(schema, device_id="DE:AD:BE:EF:FF:00")
 
+# create device with invalid macaddr
+try:
+  dev2_invalid = Device.from_schema(schema, device_id="DE:AD:BE")
+  assert False
+except ValueError as err:
+  assert (
+    err.args[0]
+    == "the vendor device id must a valid MAC address"
+  )
+
 # check printing
 assert str(dev1) == "'<Device12: DE:AD:BE:EF:FF:00>'"
 


### PR DESCRIPTION
We were not validating the vendor device id properly. The examples in the README are wrong too.

Thanks to @teddynecsoiu for detecting this.